### PR TITLE
Rethrow exception if not valid for retry

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -84,11 +84,7 @@ class Statement implements \IteratorAggregate, DriverStatement
                     $attempt++;
                     $retry = true;
                 } else {
-                    throw DBALException::driverExceptionDuringQuery(
-                        $e,
-                        $this->sql,
-                        $this->conn->resolveParams($this->params, $this->types)
-                    );
+                    throw $e;
                 }
             }
         }


### PR DESCRIPTION
Doctrine 2.5 redefined DBALException::driverExceptionDuringQuery, requiring also the driver.
That lead to a Catchable Fatal Error if something goes wrong during the query (ex. in my case: not nullable value left as null).

The call is unneeded, a simple rethrow will suffice.