### PR TITLE
Duplicate logic in the statement wrapper causing problems

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -191,7 +191,7 @@ class Connection extends \Doctrine\DBAL\Connection
      * do not use, only used by Statement-class
      * needs to be public for access from the Statement-class
      *
-     * @deprecated
+     * @internal
      */
     public function prepareUnwrapped($sql)
     {


### PR DESCRIPTION
The `Doctrine\DBAL\Statement` wrapper recreates a lot of the logic of the underlying `Doctrine\DBAL\Statement` object, and this causes that logic to happen twice. This causes a lot of side-effects, like the query logger being called twice, and the types that are getting passed to the underlying driver being converted twice.

Because the wrapper is passed `Doctrine\DBAL\Statement` directly, the wrapper can just pass all these method calls directly to the statement.