### PR TITLE
Better detection of MySQL server has gone away

### DIFF
--- a/src/Driver/PDOMySql/Driver.php
+++ b/src/Driver/PDOMySql/Driver.php
@@ -11,25 +11,14 @@ use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Driver\ServerGoneAwayExceptionsAw
 class Driver extends \Doctrine\DBAL\Driver\PDOMySql\Driver implements ServerGoneAwayExceptionsAwareInterface
 {
     /**
-     * @var array
-     */
-    protected $goneAwayExceptions = array(
-        'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away',
-        'PDOStatement::execute(): MySQL server has gone away'
-    );
-
-    /**
      * @param \Exception $exception
      * @return bool
      */
     public function isGoneAwayException(\Exception $exception)
     {
         $message = $exception->getMessage();
-
-        foreach ($this->goneAwayExceptions as $goneAwayException) {
-            if (strpos($message, $goneAwayException) !== false) {
-                return true;
-            }
+        if (strpos($message, 'MySQL server has gone away') !== false) {
+            return true;
         }
 
         return false;


### PR DESCRIPTION
"PDO::query(): MySQL server has gone away" could also be thrown.