### PR TITLE
referencing class with ::class does not work with php 5.4

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -248,7 +248,7 @@ class Connection extends \Doctrine\DBAL\Connection
     private function resetTransactionNestingLevel()
     {
         if(!$this->selfReflectionNestingLevelProperty instanceof \ReflectionProperty) {
-            $reflection = new \ReflectionClass(parent::class);
+            $reflection = new \ReflectionClass('Doctrine\DBAL\Connection');
             $this->selfReflectionNestingLevelProperty = $reflection->getProperty("_transactionNestingLevel");
             $this->selfReflectionNestingLevelProperty->setAccessible(true);
         }


### PR DESCRIPTION
Using ::class notation with php <5.5 causes a Parse error like :

> Parse error: syntax error, unexpected 'class' (T_CLASS), expecting identifier (T_STRING) or variable (T_VARIABLE) or '{' or '$'

Fixed with this pr, otherwise the contraint must be changed.
