### PR TITLE
Missing testsuite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 vendor
+bin
 composer.phar
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,69 @@
+language: php
+
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+matrix:
+  fast_finish: true
+  include:
+    - php: '5.4'
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: '5.4'
+      env: SYMFONY=2.8.*
+
+    - php: '5.5'
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: '5.5'
+      env: SYMFONY=2.8.*
+    - php: '5.5'
+      env: SYMFONY=3.0.*
+
+    - php: '5.6'
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: '5.6'
+      env: SYMFONY=2.8.*
+    - php: '5.6'
+      env: SYMFONY=3.0.*
+    - php: '5.6'
+      env: SYMFONY=3.1.*
+
+    - php: '7.0'
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: '7.0'
+      env: SYMFONY=2.8.*
+    - php: '7.0'
+      env: SYMFONY=3.0.*
+    - php: '7.0'
+      env: SYMFONY=3.1.*
+    - php: '7.0'
+      env: SYMFONY=dev-master
+
+  allow_failures:
+    - env: SYMFONY=3.1.*
+    - env: SYMFONY=dev-master
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+before_install:
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi;
+  - composer self-update
+  - if [ "$SYMFONY" != "" ]; then composer require "symfony/symfony:${SYMFONY}" --no-update; fi;
+
+install:
+  - composer update --prefer-dist --no-interaction ${COMPOSER_FLAGS}
+
+before_script:
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "zend_extension=xdebug.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+
+script:
+  - bin/phpunit
+
+notifications:
+  on_success: never
+  on_failure: always

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,6 @@
     "name": "facile-it/doctrine-mysql-come-back",
     "description": "Auto reconnect on Doctrine MySql has gone away exceptions on doctrine/dbal",
     "keywords": ["mysql","doctrine","reconnect","refresh","connection","has gone away","exception"],
-    "require": {
-        "php" : ">=5.4",
-        "doctrine/dbal": ">=2.3,<2.6-dev"
-    },
     "license": "Apache License Version 2.0",
     "authors": [
         {
@@ -13,8 +9,19 @@
             "email": "luca.boeri@facile.it"
         }
     ],
+    "require": {
+        "php" : ">=5.4",
+        "doctrine/dbal": ">=2.3,<2.6-dev"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8"
+    },
     "autoload": {
         "psr-4": { "Facile\\DoctrineMySQLComeBack\\Doctrine\\DBAL\\": "src/" }
+    },
+    "config": {
+        "preferred-install": "dist",
+        "bin-dir": "bin"
     },
     "minimum-stability": "stable"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="doctrine-mysql-come-back testsuite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+            <exclude>
+                <directory>./tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/unit/StatementTest.php
+++ b/tests/unit/StatementTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Statement;
+
+class StatementTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function test_construction()
+    {
+        $sql = 'SELECT 1';
+        $connection = $this->prophesize('Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection');
+        $connection
+            ->prepareUnwrapped($sql)
+            ->shouldBeCalledTimes(1);
+
+        $statement = new Statement($sql, $connection->reveal());
+
+        $this->assertInstanceOf('Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Statement', $statement);
+    }    
+    
+}


### PR DESCRIPTION
**Proposal for adding a test suite**

added: 
- travis configuration testing against php >= 5.4 including symfony to verify conficts
- phpunit configuration and dev-dependency
- a simple and incomplete test to start

we must create a travis accunt and enable the repo if this well be merged