### PR TITLE
Drop older dependencies

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,22 @@
+checks:
+  php: true
+
+coding_style:
+  php:
+    spaces:
+      around_operators:
+        concatenation: true
+        negation: true
+      other:
+        after_type_cast: false
+
+tools:
+  external_code_coverage: true
+
+  php_code_sniffer:
+    config:
+      standard: "PSR2"
+
+filter:
+  excluded_paths:
+    - tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,17 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 env:
   - COMPOSER_FLAGS="--prefer-lowest"
   - COMPOSER_FLAGS=""
 
 matrix:
   fast_finish: true
+  include:
+    - php: hhvm
+      sudo: required
+      dist: trusty
+      group: edge
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
 matrix:
   fast_finish: true
   include:
+    - php: 7.1
+      env: 
+        - TEST_COVERAGE=true
     - php: hhvm
       sudo: required
       dist: trusty
@@ -37,7 +40,10 @@ install:
   - composer update --prefer-dist --no-interaction ${COMPOSER_FLAGS}
 
 script:
-  - bin/phpunit
+  - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr bin/phpunit --coverage-clover clover.xml; else bin/phpunit; fi;
+
+after_success:
+  - if [[ $TEST_COVERAGE ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover ./clover.xml; fi
 
 notifications:
   on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,18 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
-
+env:
+  - COMPOSER_FLAGS="--prefer-lowest"
+  - SYMFONY=2.8.*
+  - SYMFONY=""
+  - SYMFONY=dev-master
 matrix:
   fast_finish: true
-  include:
-    - php: '5.4'
-      env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: '5.4'
-      env: SYMFONY=2.8.*
-
-    - php: '5.5'
-      env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: '5.5'
-      env: SYMFONY=2.8.*
-    - php: '5.5'
-      env: SYMFONY=3.0.*
-
-    - php: '5.6'
-      env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: '5.6'
-      env: SYMFONY=2.8.*
-    - php: '5.6'
-      env: SYMFONY=3.0.*
-    - php: '5.6'
-      env: SYMFONY=3.1.*
-
-    - php: '7.0'
-      env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: '7.0'
-      env: SYMFONY=2.8.*
-    - php: '7.0'
-      env: SYMFONY=3.0.*
-    - php: '7.0'
-      env: SYMFONY=3.1.*
-    - php: '7.0'
-      env: SYMFONY=dev-master
-
   allow_failures:
-    - env: SYMFONY=3.1.*
     - env: SYMFONY=dev-master
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,14 @@ matrix:
       sudo: required
       dist: trusty
       group: edge
+      env:
+        - COMPOSER_FLAGS="--prefer-lowest"
+    - php: hhvm
+      sudo: required
+      dist: trusty
+      group: edge
+      env:
+        - COMPOSER_FLAGS=""
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+sudo: false
 
 php:
   - 5.6
@@ -7,13 +8,10 @@ php:
   - hhvm
 env:
   - COMPOSER_FLAGS="--prefer-lowest"
-  - SYMFONY=2.8.*
-  - SYMFONY=""
-  - SYMFONY=dev-master
+  - COMPOSER_FLAGS=""
+
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: SYMFONY=dev-master
 
 cache:
   directories:
@@ -22,13 +20,9 @@ cache:
 before_install:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi;
   - composer self-update
-  - if [ "$SYMFONY" != "" ]; then composer require "symfony/symfony:${SYMFONY}" --no-update; fi;
 
 install:
   - composer update --prefer-dist --no-interaction ${COMPOSER_FLAGS}
-
-before_script:
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "zend_extension=xdebug.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
 
 script:
   - bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-[![Latest Stable Version](https://poser.pugx.org/facile-it/doctrine-mysql-come-back/v/stable.svg)](https://packagist.org/packages/facile-it/doctrine-mysql-come-back) [![Total Downloads](https://poser.pugx.org/facile-it/doctrine-mysql-come-back/downloads.svg)](https://packagist.org/packages/facile-it/doctrine-mysql-come-back) [![Latest Unstable Version](https://poser.pugx.org/facile-it/doctrine-mysql-come-back/v/unstable.svg)](https://packagist.org/packages/facile-it/doctrine-mysql-come-back) [![License](https://poser.pugx.org/facile-it/doctrine-mysql-come-back/license.svg)](https://packagist.org/packages/facile-it/doctrine-mysql-come-back)
+[![Latest Stable Version](https://poser.pugx.org/facile-it/doctrine-mysql-come-back/v/stable.svg)](https://packagist.org/packages/facile-it/doctrine-mysql-come-back) 
+[![Latest Unstable Version](https://poser.pugx.org/facile-it/doctrine-mysql-come-back/v/unstable.svg)](https://packagist.org/packages/facile-it/doctrine-mysql-come-back) 
+[![Total Downloads](https://poser.pugx.org/facile-it/doctrine-mysql-come-back/downloads.svg)](https://packagist.org/packages/facile-it/doctrine-mysql-come-back) 
+
+[![Build status](https://travis-ci.org/facile-it/doctrine-mysql-come-back.svg)]( https://travis-ci.org/facile-it/doctrine-mysql-come-back)
+[![Scrutinizer score](https://scrutinizer-ci.com/g/facile-it/doctrine-mysql-come-back/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/facile-it/doctrine-mysql-come-back/?branch=master)
+[![Test coverage](https://scrutinizer-ci.com/g/facile-it/doctrine-mysql-come-back/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/facile-it/doctrine-mysql-come-back/?branch=master)
+
+[![License](https://poser.pugx.org/facile-it/doctrine-mysql-come-back/license.svg)](https://packagist.org/packages/facile-it/doctrine-mysql-come-back)
 # DoctrineMySQLComeBack
 
 Auto reconnect on Doctrine MySql has gone away exceptions on doctrine/dbal >=2.3,<2.6-dev.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "doctrine/dbal": ">=2.3,<2.6-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.2",
+        "phpunit/phpunit": "^5.4.3 || ^6.0",
         "friendsofphp/php-cs-fixer": "^2.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php" : "^5.4 || ^7.0",
+        "php" : "^5.6 || ^7.0",
         "doctrine/dbal": ">=2.3,<2.6-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.2",
-        "friendsofphp/php-cs-fixer": "^1.11"
+        "phpunit/phpunit": "^6.0",
+        "friendsofphp/php-cs-fixer": "^2.3"
     },
     "autoload": {
         "psr-4": { "Facile\\DoctrineMySQLComeBack\\Doctrine\\DBAL\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "doctrine/dbal": ">=2.3,<2.6-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^4.8 || ^5.2",
         "friendsofphp/php-cs-fixer": "^2.3"
     },
     "autoload": {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -7,20 +7,17 @@ use Doctrine\DBAL\Driver;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Driver\ServerGoneAwayExceptionsAwareInterface;
+use Doctrine\DBAL\Connection as DBALConnection;
 
 /**
  * Class Connection.
  */
-class Connection extends \Doctrine\DBAL\Connection
+class Connection extends DBALConnection
 {
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $reconnectAttempts = 0;
 
-    /**
-     * @var \ReflectionProperty|null
-     */
+    /** @var \ReflectionProperty|null */
     private $selfReflectionNestingLevelProperty;
 
     /**
@@ -30,6 +27,7 @@ class Connection extends \Doctrine\DBAL\Connection
      * @param EventManager                                  $eventManager
      *
      * @throws \InvalidArgumentException
+     * @throws \Doctrine\DBAL\DBALException
      */
     public function __construct(
         array $params,
@@ -37,14 +35,14 @@ class Connection extends \Doctrine\DBAL\Connection
         Configuration $config = null,
         EventManager $eventManager = null
     ) {
-        if (!$driver instanceof ServerGoneAwayExceptionsAwareInterface) {
+        if (! $driver instanceof ServerGoneAwayExceptionsAwareInterface) {
             throw new \InvalidArgumentException(
                 sprintf('%s needs a driver that implements ServerGoneAwayExceptionsAwareInterface', get_class($this))
             );
         }
 
         if (isset($params['driverOptions']['x_reconnect_attempts'])) {
-            $this->reconnectAttempts = (int) $params['driverOptions']['x_reconnect_attempts'];
+            $this->reconnectAttempts = (int)$params['driverOptions']['x_reconnect_attempts'];
         }
 
         parent::__construct($params, $driver, $config, $eventManager);
@@ -269,8 +267,8 @@ class Connection extends \Doctrine\DBAL\Connection
      */
     private function resetTransactionNestingLevel()
     {
-        if (!$this->selfReflectionNestingLevelProperty instanceof \ReflectionProperty) {
-            $reflection = new \ReflectionClass('Doctrine\DBAL\Connection');
+        if (! $this->selfReflectionNestingLevelProperty instanceof \ReflectionProperty) {
+            $reflection = new \ReflectionClass(DBALConnection::class);
             $this->selfReflectionNestingLevelProperty = $reflection->getProperty('_transactionNestingLevel');
             $this->selfReflectionNestingLevelProperty->setAccessible(true);
         }
@@ -285,6 +283,6 @@ class Connection extends \Doctrine\DBAL\Connection
      */
     public function isUpdateQuery($query)
     {
-        return !preg_match('/^[\s\n\r\t(]*(select|show|describe)[\s\n\r\t(]+/i', $query);
+        return ! preg_match('/^[\s\n\r\t(]*(select|show|describe)[\s\n\r\t(]+/i', $query);
     }
 }

--- a/src/Driver/ServerGoneAwayExceptionsAwareTrait.php
+++ b/src/Driver/ServerGoneAwayExceptionsAwareTrait.php
@@ -7,20 +7,16 @@ namespace Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Driver;
  */
 trait ServerGoneAwayExceptionsAwareTrait
 {
-    /**
-     * @var array
-     */
-    protected $goneAwayExceptions = array(
+    /** @var string[] */
+    protected $goneAwayExceptions = [
         'MySQL server has gone away',
         'Lost connection to MySQL server during query',
-    );
+    ];
 
-    /**
-     * @var array
-     */
-    protected $goneAwayInUpdateExceptions = array(
+    /** @var string[] */
+    protected $goneAwayInUpdateExceptions = [
         'MySQL server has gone away',
-    );
+    ];
 
     /**
      * @param \Exception $exception

--- a/tests/unit/ConnectionTest.php
+++ b/tests/unit/ConnectionTest.php
@@ -2,20 +2,24 @@
 
 namespace Facile\DoctrineMySQLComeBack\Doctrine\DBAL;
 
+use Doctrine\DBAL\Driver;
+use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Driver\ServerGoneAwayExceptionsAwareInterface;
+use Doctrine\DBAL\Configuration;
+use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
 class ConnectionTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var Connection
-     */
+    /** @var Connection */
     protected $connection;
 
     public function setUp()
     {
-        $driver = $this->prophesize('Doctrine\DBAL\Driver')
-            ->willImplement('Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Driver\ServerGoneAwayExceptionsAwareInterface');
-        $configuration = $this->prophesize('Doctrine\DBAL\Configuration');
-        $eventManager = $this->prophesize('Doctrine\Common\EventManager');
-        $platform = $this->prophesize('Doctrine\DBAL\Platforms\AbstractPlatform');
+        $driver = $this->prophesize(Driver::class)
+            ->willImplement(ServerGoneAwayExceptionsAwareInterface::class);
+        $configuration = $this->prophesize(Configuration::class);
+        $eventManager = $this->prophesize(EventManager::class);
+        $platform = $this->prophesize(AbstractPlatform::class);
 
         $params = [
             'driverOptions' => [
@@ -32,13 +36,13 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testContructor()
+    public function testConstructor()
     {
-        $driver = $this->prophesize('Doctrine\DBAL\Driver')
-            ->willImplement('Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Driver\ServerGoneAwayExceptionsAwareInterface');
-        $configuration = $this->prophesize('Doctrine\DBAL\Configuration');
-        $eventManager = $this->prophesize('Doctrine\Common\EventManager');
-        $platform = $this->prophesize('Doctrine\DBAL\Platforms\AbstractPlatform');
+        $driver = $this->prophesize(Driver::class)
+            ->willImplement(ServerGoneAwayExceptionsAwareInterface::class);
+        $configuration = $this->prophesize(Configuration::class);
+        $eventManager = $this->prophesize(EventManager::class);
+        $platform = $this->prophesize(AbstractPlatform::class);
 
         $params = [
             'driverOptions' => [
@@ -54,18 +58,18 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             $eventManager->reveal()
         );
 
-        static::assertInstanceOf('Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection', $connection);
+        static::assertInstanceOf(Connection::class, $connection);
     }
 
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testContructorWithInvalidDriver()
+    public function testConstructorWithInvalidDriver()
     {
-        $driver = $this->prophesize('Doctrine\DBAL\Driver');
-        $configuration = $this->prophesize('Doctrine\DBAL\Configuration');
-        $eventManager = $this->prophesize('Doctrine\Common\EventManager');
-        $platform = $this->prophesize('Doctrine\DBAL\Platforms\AbstractPlatform');
+        $driver = $this->prophesize(Driver::class);
+        $configuration = $this->prophesize(Configuration::class);
+        $eventManager = $this->prophesize(EventManager::class);
+        $platform = $this->prophesize(AbstractPlatform::class);
 
         $params = [
             'driverOptions' => [
@@ -81,7 +85,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             $eventManager->reveal()
         );
 
-        static::assertInstanceOf('Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection', $connection);
+        static::assertInstanceOf(Connection::class, $connection);
     }
 
     /**

--- a/tests/unit/ConnectionTest.php
+++ b/tests/unit/ConnectionTest.php
@@ -7,8 +7,9 @@ use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Driver\ServerGoneAwayExceptionsAw
 use Doctrine\DBAL\Configuration;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use PHPUnit\Framework\TestCase;
 
-class ConnectionTest extends \PHPUnit_Framework_TestCase
+class ConnectionTest extends TestCase
 {
     /** @var Connection */
     protected $connection;

--- a/tests/unit/StatementTest.php
+++ b/tests/unit/StatementTest.php
@@ -1,21 +1,20 @@
 <?php
 
+use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection;
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Statement;
 
 class StatementTest extends \PHPUnit_Framework_TestCase
 {
-
     public function test_construction()
     {
         $sql = 'SELECT 1';
-        $connection = $this->prophesize('Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection');
+        $connection = $this->prophesize(Connection::class);
         $connection
             ->prepareUnwrapped($sql)
             ->shouldBeCalledTimes(1);
 
         $statement = new Statement($sql, $connection->reveal());
 
-        $this->assertInstanceOf('Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Statement', $statement);
-    }    
-    
+        $this->assertInstanceOf(Statement::class, $statement);
+    }
 }

--- a/tests/unit/StatementTest.php
+++ b/tests/unit/StatementTest.php
@@ -3,7 +3,7 @@
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection;
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Statement;
 
-class StatementTest extends \PHPUnit_Framework_TestCase
+class StatementTest extends \PHPUnit\Framework\TestCase
 {
     public function test_construction()
     {


### PR DESCRIPTION
This PR tries to bump up the versions required by this package. I'm not sure if this will require a major version bump, but we can decide this later; in fact, no functionality has been changed, only `::class` is used everywhere was possible so the PHP version constraint should take care of everything.

In summary, this PR implements this changes:

 - raise requirement to PHP 5.6
 - bump version of PHPUnit to ^5.4|^6
 - bump CS fixer to latest version
 - simplify the Travis CI matrix
 - eliminates Symfony requirement from the CI (it wasn't needed!)
 - add Scrutinizer
 - add test coverage collection