### PR TITLE
Add compatibility with doctrine/dbal 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+ * Compatibility with doctrine/dbal up to version 2.6 (#22)
+
+### Changed
+ * Bumped minimum PHP version to 5.6 (#21)
+ * Updated various dev dependecies
+ * Simplified the Travis CI build matrix
+
+## [1.6.3] - 2016-09-30
+### Added
+ * Added a test suite
+
+### Fixed
+ * Fix issue for not retrying a query that has a new line after the `SELECT` keyword (#19)
+ * Avoid retrying `UPDATE` queries to avoid issues (#17)
+ 
+## [1.6.2] - 2016-06-03
+### Added
+ * Added a test suite (#16)
+ * Added a configuration example for ZendFramework (#13)
+
+### Fixed
+ * Fix issue with `Driver::connect()` (#14) 
+ 
+## [1.6.1] - 2016-05-16
+### Added
+ * Add support for MySQLi (#9)
+
+### Changed
+ * Refactor and eliminate duplication using a trait
+
+### Fixed
+ * Explicit the requirement for PHP >= 5.4
+ 
+## [1.6] - 2015-11-26
+### Added
+ * Create the `ServerGoneAwayExceptionsAwareInterface`
+
+### Fixed
+ * Handle correctly the retrying of `beginTransaction()`

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php" : "^5.6 || ^7.0",
-        "doctrine/dbal": ">=2.3,<2.6-dev"
+        "doctrine/dbal": ">=2.3,<2.7-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.4.3 || ^6.0",

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -152,23 +152,24 @@ class Statement implements \IteratorAggregate, DriverStatement
 
     /**
      * @param int|null $fetchMode
-     *
+     * @param int $cursorOrientation Only for doctrine/DBAL >= 2.6
+     * @param int $cursorOffset Only for doctrine/DBAL >= 2.6
      * @return mixed
      */
-    public function fetch($fetchMode = null)
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
-        return $this->stmt->fetch($fetchMode);
+        return $this->stmt->fetch($fetchMode, $cursorOrientation, $cursorOffset);
     }
 
     /**
      * @param int|null $fetchMode
-     * @param int      $fetchArgument
-     *
+     * @param int $fetchArgument Only for doctrine/DBAL >= 2.6
+     * @param null $ctorArgs Only for doctrine/DBAL >= 2.6
      * @return mixed
      */
-    public function fetchAll($fetchMode = null, $fetchArgument = 0)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
-        return $this->stmt->fetchAll($fetchMode, $fetchArgument);
+        return $this->stmt->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
     }
 
     /**


### PR DESCRIPTION
As the [upgrade guide](https://github.com/doctrine/dbal/blob/master/UPGRADE.md#upgrade-to-26) of `doctrine/dbal` states, those are the only differences needed to up the compatibility of this package to 2.6.