### PR TITLE
use interface to be compatible

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -37,7 +37,7 @@ class Statement extends \Doctrine\DBAL\Statement
      * @param $sql
      * @param Connection $conn
      */
-    public function __construct($sql, Connection $conn)
+    public function __construct($sql, ConnectionInterface $conn)
     {
         // Mysqli executes statement on Statement constructor, so we should retry to reconnect here too
         $attempt = 0;


### PR DESCRIPTION
provided connection class PrimaryReadReplicaConnection is no child from \Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection. this causes issues when doing this:

    $entityManager->getConnection()->prepare($sql)

 therefore the implementation of the ConnectionInterface is neccessarly needed to call "prepare" on PrimaryReadReplicaConnection.