### PR TITLE
PdoException is not catched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 * Adedd handling of AWS MySQL RDS connection loss
+* Fixed `beginTransaction` function to have reconnection support
 
 ## [2.0.0-BETA1] - 2022-06-23
 ### Added

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -10,11 +10,11 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection as DBALConnection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Exception;
-use PDOException;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Statement as DBALStatement;
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Detector\GoneAwayDetector;
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Detector\MySQLGoneAwayDetector;
+use PDOException;
 
 class Connection extends DBALConnection
 {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -9,7 +9,8 @@ use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection as DBALConnection;
 use Doctrine\DBAL\Driver;
-use Exception;
+use Doctrine\DBAL\Exception;
+use PDOException;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Statement as DBALStatement;
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Detector\GoneAwayDetector;
@@ -63,7 +64,7 @@ class Connection extends DBALConnection
                 $driverStatement = @$this->_conn->prepare($sql);
 
                 return new Statement($this, $driverStatement, $sql);
-            } catch (Exception $e) {
+            } catch (Exception|PDOException $e) {
                 if ($this->canTryAgain($e, $attempt)) {
                     $this->close();
                     ++$attempt;
@@ -83,7 +84,7 @@ class Connection extends DBALConnection
             $retry = false;
             try {
                 return @parent::executeQuery($sql, $params, $types, $qcp);
-            } catch (Exception $e) {
+            } catch (Exception|PDOException $e) {
                 if ($this->canTryAgain($e, $attempt, $sql)) {
                     $this->close();
                     ++$attempt;
@@ -103,7 +104,7 @@ class Connection extends DBALConnection
             $retry = false;
             try {
                 return @parent::executeStatement($sql, $params, $types);
-            } catch (Exception $e) {
+            } catch (Exception|PDOException $e) {
                 if ($this->canTryAgain($e, $attempt, $sql)) {
                     $this->close();
                     ++$attempt;
@@ -127,7 +128,7 @@ class Connection extends DBALConnection
             $retry = false;
             try {
                 return @parent::beginTransaction();
-            } catch (Exception $e) {
+            } catch (Exception|PDOException $e) {
                 if ($this->canTryAgain($e, $attempt, '', true)) {
                     $this->close();
                     if (0 < $this->getTransactionNestingLevel()) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -128,7 +128,7 @@ class Connection extends DBALConnection
             try {
                 return @parent::beginTransaction();
             } catch (Exception $e) {
-                if ($this->canTryAgain($e, $attempt)) {
+                if ($this->canTryAgain($e, $attempt, '', true)) {
                     $this->close();
                     if (0 < $this->getTransactionNestingLevel()) {
                         $this->resetTransactionNestingLevel();

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection as DBALConnection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Exception;
+use Exception;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Statement as DBALStatement;
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Detector\GoneAwayDetector;
@@ -63,7 +63,7 @@ class Connection extends DBALConnection
                 $driverStatement = @$this->_conn->prepare($sql);
 
                 return new Statement($this, $driverStatement, $sql);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 if ($this->canTryAgain($e, $attempt)) {
                     $this->close();
                     ++$attempt;

--- a/tests/functional/AbstractFunctionalTest.php
+++ b/tests/functional/AbstractFunctionalTest.php
@@ -209,6 +209,9 @@ TABLE
         $result = $statement->executeQuery()->fetchAllNumeric();
 
         $this->assertSame([['0' => 'foo']], $result);
+        /**
+         * @psalm-suppress DocblockTypeContradiction
+         */
         $this->assertSame(2, $connection->connectCount);
     }
 }

--- a/tests/functional/AbstractFunctionalTest.php
+++ b/tests/functional/AbstractFunctionalTest.php
@@ -95,6 +95,28 @@ TABLE
         $this->assertSame(2, $connection->connectCount);
     }
 
+    public function testBeginTransactionShouldNotReconnect(): void
+    {
+        $connection = $this->getConnectedConnection(0);
+        $this->assertSame(1, $connection->connectCount);
+        $this->forceDisconnect($connection);
+
+        $this->expectException(\PDOException::class);
+
+        $connection->beginTransaction();
+    }
+
+    public function testBeginTransactionShouldReconnect(): void
+    {
+        $connection = $this->getConnectedConnection(1);
+        $this->assertSame(1, $connection->connectCount);
+        $this->forceDisconnect($connection);
+
+        $connection->beginTransaction();
+
+        $this->assertSame(2, $connection->connectCount);
+    }
+
     public function testQueryShouldReconnect(): void
     {
         $connection = $this->getConnectedConnection(1);

--- a/tests/functional/AbstractFunctionalTest.php
+++ b/tests/functional/AbstractFunctionalTest.php
@@ -98,10 +98,13 @@ TABLE
     public function testBeginTransactionShouldNotReconnect(): void
     {
         $connection = $this->getConnectedConnection(0);
+        $driver = $connection->getDriver();
         $this->assertSame(1, $connection->connectCount);
         $this->forceDisconnect($connection);
 
-        $this->expectException(\PDOException::class);
+        if (is_a($driver, Driver::class)) {
+            $this->expectException(\PDOException::class);
+        }
 
         $connection->beginTransaction();
     }
@@ -109,12 +112,17 @@ TABLE
     public function testBeginTransactionShouldReconnect(): void
     {
         $connection = $this->getConnectedConnection(1);
+        $driver = $connection->getDriver();
         $this->assertSame(1, $connection->connectCount);
         $this->forceDisconnect($connection);
 
         $connection->beginTransaction();
 
-        $this->assertSame(2, $connection->connectCount);
+        if (is_a($driver, Driver::class)) {
+            $this->assertSame(2, $connection->connectCount);
+        } else {
+            $this->assertSame(1, $connection->connectCount);
+        }
     }
 
     public function testQueryShouldReconnect(): void


### PR DESCRIPTION
Because you are using `Doctrine\DBAL\Exception` PdoException is not catched. This change is similar to approach from previous version of library for Doctrine 2.X

https://github.com/facile-it/doctrine-mysql-come-back/issues/63