### PR TITLE
doctrine/dbal ^4.0.0

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,1 @@
+PHP_VERSION=8.1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.0"
           - "8.1"
           - "8.2"
           - "8.3"
@@ -31,22 +30,26 @@ jobs:
         custom-entrypoint:
           - --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
         include:
-          - php-version: "8.0"
+          - php-version: "8.3"
             mysql-version: "8.0"
             custom-entrypoint: ~
             job: Tests
-          - php-version: "8.0"
+
+          - php-version: "8.3"
             mysql-version: "5.7"
             custom-entrypoint: ~
             job: Tests
-          - php-version: "8.2"
+
+          - php-version: "8.3"
             mysql-version: "5.7"
             job: Tests
-          - php-version: "8.1"
+
+          - php-version: "8.3"
             mysql-version: "8.0"
             job: Infection
+
           - dependencies: "lowest"
-            php-version: "8.0"
+            php-version: "8.1"
             mysql-version: "5.7"
             name: Lowest deps
 
@@ -119,7 +122,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: ${{ matrix.php-version }}
 
       - name: Install dependencies
         uses: ramsey/composer-install@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -111,7 +111,7 @@ jobs:
             command: vendor/bin/php-cs-fixer fix --dry-run --ansi --verbose
           - name: Psalm
             commandName: Run Psalm analysis
-            command: vendor/bin/php-cs-fixer fix --dry-run --ansi --verbose
+            command: vendor/bin/psalm --show-info=true
 
     steps:
       - name: Checkout

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,24 +30,11 @@ jobs:
         custom-entrypoint:
           - --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
         include:
-          - php-version: "8.3"
-            mysql-version: "8.0"
-            custom-entrypoint: ~
-            job: Tests
-
-          - php-version: "8.3"
+          - php-version: "8.2"
             mysql-version: "5.7"
-            custom-entrypoint: ~
-            job: Tests
-
-          - php-version: "8.3"
-            mysql-version: "5.7"
-            job: Tests
-
           - php-version: "8.3"
             mysql-version: "8.0"
             job: Infection
-
           - dependencies: "lowest"
             php-version: "8.1"
             mysql-version: "5.7"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
           - "8.0"
           - "8.1"
           - "8.2"
@@ -32,11 +31,11 @@ jobs:
         custom-entrypoint:
           - --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
         include:
-          - php-version: "7.4"
+          - php-version: "8.0"
             mysql-version: "8.0"
             custom-entrypoint: ~
             job: Tests
-          - php-version: "7.4"
+          - php-version: "8.0"
             mysql-version: "5.7"
             custom-entrypoint: ~
             job: Tests
@@ -47,7 +46,7 @@ jobs:
             mysql-version: "8.0"
             job: Infection
           - dependencies: "lowest"
-            php-version: "7.4"
+            php-version: "8.0"
             mysql-version: "5.7"
             name: Lowest deps
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /docker-compose.override.yml
 /phpunit.xml
 /.*.cache
+.env

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/common": "^3.4",
         "doctrine/dbal": "^4.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,12 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
-        "doctrine/dbal": "^3.6.0"
+        "php": "^8.0",
+        "doctrine/common": "^3.4",
+        "doctrine/dbal": "^4.0.0"
     },
     "require-dev": {
+        "ext-pdo": "*",
         "facile-it/facile-coding-standard": "^0.5.2",
         "fig/log-test": "^1.0",
         "infection/infection": "^0.26.6",
@@ -58,7 +60,7 @@
     "minimum-stability": "stable",
     "scripts": {
         "test": "phpunit",
-        "phpcs": "php-cs-fixer fix --level=psr2 -v --diff --dry-run src/",
-        "phpcs-fix": "php-cs-fixer fix --level=psr2 -v --diff src/"
+        "phpcs": "php-cs-fixer fix --dry-run --diff",
+        "phpcs-fix": "php-cs-fixer fix --diff"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     ],
     "require": {
         "php": "^8.1",
-        "doctrine/common": "^3.4",
         "doctrine/dbal": "^4.0.0"
     },
     "require-dev": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,10 +32,11 @@ services:
 
   php:
     <<: *php-props
+    image: facile.example.com/php:${PHP_VERSION}
     build:
       context: ./docker
       args:
-        PHP_VERSION: "8.1"
+        PHP_VERSION: ${PHP_VERSION}
     depends_on:
       - mysql80
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,9 +34,11 @@ services:
     <<: *php-props
     build:
       context: ./docker
+      args:
+        PHP_VERSION: "8.0"
     depends_on:
-      - mysql57
+      - mysql80
     environment:
       PHP_IDE_CONFIG: serverName=MySQLComeBack
-      MYSQL_HOST: mysql57
+      MYSQL_HOST: mysql80
       MYSQL_DRIVER: pdo_mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     build:
       context: ./docker
       args:
-        PHP_VERSION: "8.0"
+        PHP_VERSION: "8.1"
     depends_on:
       - mysql80
     environment:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,11 @@ RUN set -ex \
 RUN adduser -D -u 1000 facile -G www-data \
     && mkdir -p /home/facile \
     && chown -R facile /home/facile
+# zsh / OhMyZsh
+RUN apk --no-cache add git zsh
 
 RUN curl -sS https://getcomposer.org/installer | php -- \
     --install-dir=/usr/local/bin --filename=composer
 
 USER facile
+RUN sh -c "$(curl -fsSLv https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=8.0
 FROM php:${PHP_VERSION}-cli-alpine
 
 RUN docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) \
@@ -7,10 +7,11 @@ RUN docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) \
 
 RUN set -ex \
     && apk add --no-cache --virtual build-dependencies \
+        linux-headers \
         autoconf \
         make \
         g++ \
-    && pecl install -o xdebug-3.1.6 && docker-php-ext-enable xdebug \
+    && pecl install -o xdebug && docker-php-ext-enable xdebug \
     && apk del build-dependencies
 
 # custom user

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=8.0
+ARG PHP_VERSION=8.1
 FROM php:${PHP_VERSION}-cli-alpine
 
 RUN docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) \
@@ -18,12 +18,9 @@ RUN set -ex \
 RUN adduser -D -u 1000 facile -G www-data \
     && mkdir -p /home/facile \
     && chown -R facile /home/facile
-# zsh / OhMyZsh
-RUN apk --no-cache add git zsh
 
 ARG COMPOSER_VERSION=2.5.5
 RUN curl -sS https://getcomposer.org/installer | php -- \
     --install-dir=/usr/local/bin --filename=composer --version=$COMPOSER_VERSION
 
 USER facile
-RUN sh -c "$(curl -fsSLv https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"

--- a/src/ConnectionTrait.php
+++ b/src/ConnectionTrait.php
@@ -154,7 +154,7 @@ trait ConnectionTrait
     public function executeQuery(string $sql, array $params = [], $types = [], ?QueryCacheProfile $qcp = null): Result
     {
         return $this->doWithRetry(function () use ($sql, $params, $types, $qcp): Result {
-            return @parent::executeQuery($sql, $params, $types, $qcp);
+            return parent::executeQuery($sql, $params, $types, $qcp);
         }, $sql);
     }
 
@@ -171,17 +171,12 @@ trait ConnectionTrait
     public function executeStatement(string $sql, array $params = [], array $types = []): int|string
     {
         return $this->doWithRetry(function () use ($sql, $params, $types) {
-            return @parent::executeStatement($sql, $params, $types);
+            return parent::executeStatement($sql, $params, $types);
         }, $sql);
     }
 
     public function beginTransaction(): void
     {
-        if ($this->getTransactionNestingLevel() > 1) {
-            parent::beginTransaction();
-            return;
-        }
-
         $this->doWithRetry(function (): void {
             parent::beginTransaction();
         });

--- a/src/ConnectionTrait.php
+++ b/src/ConnectionTrait.php
@@ -132,7 +132,10 @@ trait ConnectionTrait
 
     public function close(): void
     {
-        $this->hasBeenClosedWithAnOpenTransaction = $this->getTransactionNestingLevel() > 1;
+        if ($this->getTransactionNestingLevel() > 0) {
+            $this->hasBeenClosedWithAnOpenTransaction = true;
+        }
+
         parent::close();
     }
 

--- a/src/ConnectionTrait.php
+++ b/src/ConnectionTrait.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Facile\DoctrineMySQLComeBack\Doctrine\DBAL;
 
-use Doctrine\Common\EventManager;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Statement as DBALStatement;
 use Doctrine\DBAL\Types\Type;
@@ -17,6 +18,9 @@ use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Detector\MySQLGoneAwayDetector;
 
 /**
  * @psalm-require-extends \Doctrine\DBAL\Connection
+ *
+ * @psalm-type WrapperParameterType = string|Type|ParameterType|ArrayParameterType
+ * @psalm-type WrapperParameterTypeArray = array<int<0, max>, WrapperParameterType>|array<string, WrapperParameterType>
  */
 trait ConnectionTrait
 {
@@ -33,8 +37,7 @@ trait ConnectionTrait
     public function __construct(
         array $params,
         Driver $driver,
-        ?Configuration $config = null,
-        ?EventManager $eventManager = null
+        ?Configuration $config = null
     ) {
         if (isset($params['driverOptions']['x_reconnect_attempts'])) {
             $this->maxReconnectAttempts = $this->validateAttemptsOption($params['driverOptions']['x_reconnect_attempts']);
@@ -47,7 +50,7 @@ trait ConnectionTrait
          * @psalm-suppress InternalMethod
          * @psalm-suppress MixedArgumentTypeCoercion
          */
-        parent::__construct($params, $driver, $config, $eventManager);
+        parent::__construct($params, $driver, $config);
     }
 
     /**
@@ -148,7 +151,8 @@ trait ConnectionTrait
     /**
      * @param string $sql
      * @param list<mixed>|array<string, mixed>                                     $params
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     *
+     * @psalm-param WrapperParameterTypeArray $types
      */
     public function executeQuery(string $sql, array $params = [], $types = [], ?QueryCacheProfile $qcp = null): Result
     {
@@ -159,8 +163,11 @@ trait ConnectionTrait
 
     /**
      * @param string $sql
-     * @param list<mixed>|array<string, mixed>                                     $params
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     * @param list<mixed>|array<string, mixed> $params
+     *
+     * @psalm-param WrapperParameterTypeArray $types
+     *
+     * @return int|numeric-string
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */

--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -2,7 +2,6 @@
 
 namespace Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connections;
 
-use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Driver;
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\ConnectionTrait;
@@ -13,13 +12,13 @@ class PrimaryReadReplicaConnection extends \Doctrine\DBAL\Connections\PrimaryRea
         __construct as __traitConstruct;
     }
 
-    public function __construct(array $params, Driver $driver, ?Configuration $config = null, ?EventManager $eventManager = null)
+    public function __construct(array $params, Driver $driver, ?Configuration $config = null)
     {
         if (isset($params['primary']['driverOptions']['x_reconnect_attempts'])) {
             $params['driverOptions']['x_reconnect_attempts'] = $this->validateAttemptsOption($params['primary']['driverOptions']['x_reconnect_attempts']);
             unset($params['primary']['driverOptions']['x_reconnect_attempts']);
         }
 
-        self::__traitConstruct($params, $driver, $config, $eventManager);
+        self::__traitConstruct($params, $driver, $config);
     }
 }

--- a/src/Detector/MySQLGoneAwayDetector.php
+++ b/src/Detector/MySQLGoneAwayDetector.php
@@ -42,7 +42,7 @@ class MySQLGoneAwayDetector implements GoneAwayDetector
 
     private function isUpdateQuery(?string $sql): bool
     {
-        return $sql && ! preg_match('/^[\s\n\r\t(]*(select|show|describe)[\s\n\r\t(]+/i', $sql);
+        return $sql !== null && ! preg_match('/^[\s\n\r\t(]*(select|show|describe)[\s\n\r\t(]+/i', $sql);
     }
 
     /**
@@ -50,6 +50,6 @@ class MySQLGoneAwayDetector implements GoneAwayDetector
      */
     private function isSavepoint(?string $sql): bool
     {
-        return $sql && str_starts_with(trim($sql), 'SAVEPOINT');
+        return $sql !== null && str_starts_with(trim($sql), 'SAVEPOINT');
     }
 }

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Facile\DoctrineMySQLComeBack\Doctrine\DBAL;
 
 use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Result;
 use Exception;
@@ -45,6 +46,8 @@ class Statement extends \Doctrine\DBAL\Statement
     private function recreateStatement(): void
     {
         $ref = new \ReflectionMethod($this->conn, 'connect');
+
+        /** @var DriverConnection $wrappedConnection */
         $wrappedConnection = $ref->invoke($this->conn);
 
         $this->stmt = $wrappedConnection->prepare($this->sql);
@@ -61,22 +64,14 @@ class Statement extends \Doctrine\DBAL\Statement
         parent::bindValue($param, $value, $type);
     }
 
-    public function executeQuery(array $params = []): Result
+    public function executeQuery(): Result
     {
-        if ($params === []) {
-            return $this->executeWithRetry([parent::class, 'executeQuery']);
-        }
-
-        return $this->executeWithRetry([parent::class, 'executeQuery'], $params);
+        return $this->executeWithRetry(fn () => parent::executeQuery());
     }
 
-    public function executeStatement(array $params = []): int
+    public function executeStatement(): int|string
     {
-        if ($params === []) {
-            return $this->executeWithRetry([parent::class, 'executeStatement']);
-        }
-
-        return $this->executeWithRetry([parent::class, 'executeStatement'], $params);
+        return $this->executeWithRetry(fn () => parent::executeStatement());
     }
 
     /**

--- a/tests/Functional/AbstractFunctionalTestCase.php
+++ b/tests/Functional/AbstractFunctionalTestCase.php
@@ -87,16 +87,21 @@ TABLE
      */
     protected function getConnectionParams(): array
     {
+        /** @var key-of<DriverManager::DRIVER_MAP> $driver */
+        $driver = (string) (getenv('MYSQL_DRIVER') !== false ? getenv('MYSQL_DRIVER') : ($GLOBALS['db_driver'] ?? 'pdo_mysql'));
+        if (!in_array($driver, DriverManager::getAvailableDrivers(), true)) {
+            $this->fail(sprintf('Invalid driver class: %s', $driver));
+        }
+
         $values = [
-            'driver' => getenv('MYSQL_DRIVER') ?: $GLOBALS['db_driver'] ?? 'pdo_mysql',
-            'dbname' => getenv('MYSQL_DBNAME') ?: $GLOBALS['db_dbname'] ?? 'test',
-            'user' => getenv('MYSQL_USER') ?: $GLOBALS['db_user'] ?? 'root',
-            'password' => getenv('MYSQL_PASS') ?: $GLOBALS['db_pass'] ?? '',
-            'host' => getenv('MYSQL_HOST') ?: $GLOBALS['db_host'] ?? 'localhost',
-            'port' => (int) (getenv('MYSQL_PORT') ?: $GLOBALS['db_port'] ?? 3306),
+            'driver' => $driver,
+            'dbname' => getenv('MYSQL_DBNAME') !== false ? getenv('MYSQL_DBNAME') : ($GLOBALS['db_dbname'] ?? 'test'),
+            'user' => getenv('MYSQL_USER') !== false ? getenv('MYSQL_USER') : ($GLOBALS['db_user'] ?? 'root'),
+            'password' => getenv('MYSQL_PASS') !== false ? getenv('MYSQL_PASS') : ($GLOBALS['db_pass'] ?? ''),
+            'host' => getenv('MYSQL_HOST') !== false ? getenv('MYSQL_HOST') : ($GLOBALS['db_host'] ?? 'localhost'),
+            'port' => (int) (getenv('MYSQL_PORT') !== false ? getenv('MYSQL_PORT') : ($GLOBALS['db_port'] ?? 3306)),
         ];
 
-        $this->assertIsString($values['driver']);
         if ($values['driver'] !== 'pdo_mysql') {
             assert($values['driver'] === 'mysqli');
         }
@@ -105,6 +110,7 @@ TABLE
         $this->assertIsString($values['password']);
         $this->assertIsString($values['host']);
 
+        /** @psalm-suppress LessSpecificReturnStatement */
         return $values;
     }
 
@@ -134,7 +140,7 @@ TABLE
     }
 
     /**
-     * @return array<string, array{class-string<Driver>, bool}>
+     * @return array<string, array{class-string<Driver>}>
      */
     public static function driverDataProvider(): array
     {

--- a/tests/Functional/AbstractFunctionalTestCase.php
+++ b/tests/Functional/AbstractFunctionalTestCase.php
@@ -89,7 +89,7 @@ TABLE
     {
         /** @var key-of<DriverManager::DRIVER_MAP> $driver */
         $driver = (string) (getenv('MYSQL_DRIVER') !== false ? getenv('MYSQL_DRIVER') : ($GLOBALS['db_driver'] ?? 'pdo_mysql'));
-        if (!in_array($driver, DriverManager::getAvailableDrivers(), true)) {
+        if (! in_array($driver, DriverManager::getAvailableDrivers(), true)) {
             $this->fail(sprintf('Invalid driver class: %s', $driver));
         }
 

--- a/tests/Functional/ConnectionTraitTest.php
+++ b/tests/Functional/ConnectionTraitTest.php
@@ -187,10 +187,6 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
 
         $connection->beginTransaction();
 
-        if ($enableSavepoints) {
-            $this->fail('With savepoints enabled, test should fail without having to trigger a further query');
-        }
-
         $connection->executeStatement('SELECT 1');
     }
 

--- a/tests/Functional/ConnectionTraitTest.php
+++ b/tests/Functional/ConnectionTraitTest.php
@@ -15,9 +15,9 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testExecuteQueryShouldNotReconnect(string $driver, bool $enableSavepoints): void
+    public function testExecuteQueryShouldNotReconnect(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 0, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 0);
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
 
@@ -31,9 +31,9 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testExecuteQueryShouldReconnect(string $driver, bool $enableSavepoints): void
+    public function testExecuteQueryShouldReconnect(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 1);
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
 
@@ -47,9 +47,9 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testQueryShouldReconnect(string $driver, bool $enableSavepoints): void
+    public function testQueryShouldReconnect(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 1);
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
 
@@ -63,9 +63,9 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testExecuteUpdateShouldReconnect(string $driver, bool $enableSavepoints): void
+    public function testExecuteUpdateShouldReconnect(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 1);
         $this->createTestTable($connection);
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
@@ -80,9 +80,9 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testExecuteStatementShouldReconnect(string $driver, bool $enableSavepoints): void
+    public function testExecuteStatementShouldReconnect(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 1);
         $this->createTestTable($connection);
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
@@ -97,9 +97,9 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testShouldReconnectOnStatementExecuteError(string $driver, bool $enableSavepoints): void
+    public function testShouldReconnectOnStatementExecuteError(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 1);
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
 
@@ -115,19 +115,17 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testShouldResetStatementOnStatementExecuteError(string $driver, bool $enableSavepoints): void
+    public function testShouldResetStatementOnStatementExecuteError(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 1);
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
 
         $statement = $connection->prepare("SELECT 'foo', ?, ?");
         $statement->bindValue(1, 'bar');
+
         $param = 'baz';
-        /** @psalm-suppress DeprecatedMethod */
-        $statement->bindParam(2, $param);
-        // change param by ref
-        $param = 'baz2';
+        $statement->bindValue(2, $param);
 
         $result = $statement->executeQuery()->fetchAllNumeric();
 
@@ -140,9 +138,9 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testShouldReconnectOnStatementFetchAllAssociative(string $driver, bool $enableSavepoints): void
+    public function testShouldReconnectOnStatementFetchAllAssociative(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 1);
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
 
@@ -158,9 +156,9 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testShouldReconnectOnStatementFetchAllNumeric(string $driver, bool $enableSavepoints): void
+    public function testShouldReconnectOnStatementFetchAllNumeric(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 1);
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
 
@@ -176,9 +174,9 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testBeginTransactionShouldNotReconnectIfNested(string $driver, bool $enableSavepoints): void
+    public function testBeginTransactionShouldNotReconnectIfNested(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 1);
         $this->assertConnectionCount(1, $connection);
 
         $connection->beginTransaction();
@@ -201,15 +199,15 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testBeginTransactionShouldNotReconnect(string $driver, bool $enableSavepoints): void
+    public function testBeginTransactionShouldNotReconnect(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 0, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 0);
         $driver = $connection->getDriver();
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
 
         if (is_a($driver, PDODriver::class)) {
-            $this->expectException(\PDOException::class);
+            $this->expectException(Driver\PDO\Exception::class);
             $this->expectExceptionMessage('MySQL server has gone away');
         }
 
@@ -221,9 +219,9 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testBeginTransactionShouldReconnect(string $driver, bool $enableSavepoints): void
+    public function testBeginTransactionShouldReconnect(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 1);
         $driver = $connection->getDriver();
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
@@ -244,9 +242,9 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testShouldReconnectOnExecutePreparedStatement(string $driver, bool $enableSavepoints): void
+    public function testShouldReconnectOnExecutePreparedStatement(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 1);
         $this->assertConnectionCount(1, $connection);
         $statement = $connection->prepare('SELECT 1');
 
@@ -261,9 +259,9 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testShouldReconnectOnExecuteQueryPreparedStatement(string $driver, bool $enableSavepoints): void
+    public function testShouldReconnectOnExecuteQueryPreparedStatement(string $driver): void
     {
-        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $connection = $this->getConnectedConnection($driver, 1);
         $this->assertConnectionCount(1, $connection);
         $statement = $connection->prepare('SELECT 1');
 

--- a/tests/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Functional/PrimaryReadReplicaConnectionTest.php
@@ -13,7 +13,7 @@ class PrimaryReadReplicaConnectionTest extends ConnectionTraitTest
     /**
      * @param class-string<Driver> $driver
      */
-    protected function createConnection(string $driver, int $attempts, bool $enableSavepoints): PrimaryReadReplicaConnection
+    protected function createConnection(string $driver, int $attempts): PrimaryReadReplicaConnection
     {
         $connection = DriverManager::getConnection(array_merge(
             [
@@ -30,7 +30,6 @@ class PrimaryReadReplicaConnectionTest extends ConnectionTraitTest
         ));
 
         $this->assertInstanceOf(PrimaryReadReplicaConnection::class, $connection);
-        $connection->setNestTransactionsWithSavepoints($enableSavepoints);
 
         return $connection;
     }
@@ -40,9 +39,9 @@ class PrimaryReadReplicaConnectionTest extends ConnectionTraitTest
      *
      * @return Connection|PrimaryReadReplicaConnection
      */
-    protected function getConnectedConnection(string $driver, int $attempts, bool $enableSavepoints): DBALConnection
+    protected function getConnectedConnection(string $driver, int $attempts): DBALConnection
     {
-        $connection = parent::getConnectedConnection($driver, $attempts, $enableSavepoints);
+        $connection = parent::getConnectedConnection($driver, $attempts);
         $this->assertInstanceOf(PrimaryReadReplicaConnection::class, $connection);
         $connection->ensureConnectedToPrimary();
 
@@ -54,9 +53,11 @@ class PrimaryReadReplicaConnectionTest extends ConnectionTraitTest
      *
      * @param class-string<Driver> $driver
      */
-    public function testBeginTransactionShouldNotInterfereWhenSwitchingToPrimary(string $driver, bool $enableSavepoints): void
+    public function testBeginTransactionShouldNotInterfereWhenSwitchingToPrimary(string $driver): void
     {
-        $connection = $this->createConnection($driver, 0, $enableSavepoints);
+        $connection = $this->createConnection($driver, 0);
+        $connection->connect();
+
         $this->assertFalse($connection->isConnectedToPrimary());
         $this->assertSame(1, $connection->connectCount);
         $this->forceDisconnect($connection);

--- a/tests/Functional/Spy/Connection.php
+++ b/tests/Functional/Spy/Connection.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Facile\DoctrineMySQLComeBack\Tests\Functional\Spy;
 
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+
 /**
  * @psalm-suppress PropertyNotSetInConstructor
  */
@@ -14,7 +16,7 @@ class Connection extends \Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection
     /**
      * @param string|null $connectionName
      */
-    public function connect($connectionName = null): bool
+    public function connect(?string $connectionName = null): DriverConnection
     {
         if (! $this->isConnected()) {
             ++$this->connectCount;

--- a/tests/Functional/Spy/PrimaryReadReplicaConnection.php
+++ b/tests/Functional/Spy/PrimaryReadReplicaConnection.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Facile\DoctrineMySQLComeBack\Tests\Functional\Spy;
 
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+
 /**
  * @psalm-suppress PropertyNotSetInConstructor
  */
@@ -11,7 +13,7 @@ class PrimaryReadReplicaConnection extends \Facile\DoctrineMySQLComeBack\Doctrin
 {
     public int $connectCount = 0;
 
-    protected function connectTo($connectionName)
+    protected function connectTo(string $connectionName): DriverConnection
     {
         if (! $this->isConnected()) {
             ++$this->connectCount;

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -14,9 +14,9 @@ class StatementTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testRetriesShouldNotRetryConnection(string $driver, bool $enableSavepoints): void
+    public function testRetriesShouldNotRetryConnection(string $driver): void
     {
-        $connection = $this->createConnection($driver, 1, $enableSavepoints);
+        $connection = $this->createConnection($driver, 1);
         $statement = $connection->prepare('SELECT 1');
         $this->forceDisconnect($connection);
 
@@ -33,12 +33,14 @@ class StatementTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testExecuteQueryWithDeprecatedPassingParams(string $driver, bool $enableSavepoints): void
+    public function testExecuteQueryWithDeprecatedPassingParams(string $driver): void
     {
-        $connection = $this->createConnection($driver, 1, $enableSavepoints);
+        $connection = $this->createConnection($driver, 1);
         $statement = $connection->prepare('SELECT ?, ?');
+        $statement->bindValue(1, 'foo');
+        $statement->bindValue(2, 'bar');
 
-        $result = $statement->executeQuery(['foo', 'bar']);
+        $result = $statement->executeQuery();
 
         $this->assertEquals([['foo', 'bar']], $result->fetchAllNumeric());
     }
@@ -48,12 +50,15 @@ class StatementTest extends AbstractFunctionalTestCase
      *
      * @param class-string<Driver> $driver
      */
-    public function testExecuteStatementWithDeprecatedPassingParams(string $driver, bool $enableSavepoints): void
+    public function testExecuteStatementWithDeprecatedPassingParams(string $driver): void
     {
-        $connection = $this->createConnection($driver, 1, $enableSavepoints);
+        $connection = $this->createConnection($driver, 1);
         $statement = $connection->prepare('SELECT ?, ?');
 
-        $result = $statement->executeStatement(['foo', 'bar']);
+        $statement->bindValue(1, 'foo');
+        $statement->bindValue(2, 'bar');
+
+        $result = $statement->executeStatement();
 
         $this->assertEquals(1, $result);
     }

--- a/tests/Unit/BaseUnitTestCase.php
+++ b/tests/Unit/BaseUnitTestCase.php
@@ -17,8 +17,6 @@ abstract class BaseUnitTestCase extends TestCase
         $configuration = $this->prophesize(Configuration::class);
         $configuration->getSchemaManagerFactory()
             ->willReturn();
-        $configuration->getSQLLogger()
-            ->willReturn(null);
         $configuration->getAutoCommit()
             ->willReturn(false);
         $configuration->getDisableTypeComments()

--- a/tests/Unit/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Unit/PrimaryReadReplicaConnectionTest.php
@@ -62,6 +62,7 @@ class PrimaryReadReplicaConnectionTest extends ConnectionTraitTestCase
             'x_reconnect_attempts' => $attempts,
         ];
 
+        /** @psalm-suppress InvalidArgument */
         return new PrimaryReadReplicaConnection(
             [
                 'primary' => $primaryConfig,

--- a/tests/Unit/StatementTest.php
+++ b/tests/Unit/StatementTest.php
@@ -17,7 +17,7 @@ class StatementTest extends BaseUnitTestCase
     use ProphecyTrait;
     use DeprecationTrait;
 
-    public function testExecuteStatementShouldThrowWhenItsNotRetriable(): void
+    public function testExecuteStatementShouldThrowWhenItsNotRetryable(): void
     {
         $connection = $this->mockConnection();
         $statement = Statement::fromDBALStatement(

--- a/tests/Unit/StatementTest.php
+++ b/tests/Unit/StatementTest.php
@@ -80,10 +80,9 @@ class StatementTest extends BaseUnitTestCase
 
         $connection->getConfiguration()
             ->willReturn($configuration->reveal());
+
         $connection->getDatabasePlatform()
             ->willReturn($databasePlatform->reveal());
-        $databasePlatform->getName()
-            ->shouldNotBeCalled();
 
         $connection->canTryAgain(Argument::type(\LogicException::class), 'SELECT 1')
             ->shouldBeCalledOnce()


### PR DESCRIPTION
This should be a major version because:
- dbal is using union type which are from PHP8.0
- dbal require php8.1

- fixed also psalm in ci (it was not running)
- increased  mutation score