### PR TITLE
Adjust to DBAL changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,8 @@
-version: "3.5"
-
 x-mysql-props: &mysql-props
   environment:
     MYSQL_DATABASE: test
     MYSQL_ROOT_PASSWORD: ""
     MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-
-x-php-props: &php-props
-  build:
-    context: ./docker
-  extra_hosts:
-    - "host.docker.internal:host-gateway"
-  volumes:
-    - ./:/app
-    - ./docker/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
-  working_dir: /app
-  command: [ "tail", '-f', '/dev/null' ]
-  environment:
-    MYSQL_DATABASE: test
-    MYSQL_USER: root
-    MYSQL_PASS: ""
 
 services:
   mysql57:
@@ -31,15 +14,28 @@ services:
     <<: *mysql-props
 
   php:
-    <<: *php-props
     image: facile.example.com/php:${PHP_VERSION}
     build:
       context: ./docker
       args:
         PHP_VERSION: ${PHP_VERSION}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - mysql80
+    volumes:
+      - ./:/app
+      - ./docker/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
+    working_dir: /app
+    command: [ "tail", '-f', '/dev/null' ]
     environment:
       PHP_IDE_CONFIG: serverName=MySQLComeBack
       MYSQL_HOST: mysql80
       MYSQL_DRIVER: pdo_mysql
+      MYSQL_DATABASE: test
+      MYSQL_USER: root
+      MYSQL_PASS: ""
+      XDEBUG_CONFIG: "log=/app/xdebug.log"
+      XDEBUG_HOST: 'host.docker.internal'
+      XDEBUG_MODE: off
+      XDEBUG_START_WITH_REQUEST: 'yes'

--- a/docker/xdebug.ini
+++ b/docker/xdebug.ini
@@ -2,4 +2,3 @@
 xdebug.start_with_request=yes
 xdebug.log=/tmp/xdebug.log
 xdebug.client_host=host.docker.internal
-xdebug.mode=debug

--- a/src/ConnectionTrait.php
+++ b/src/ConnectionTrait.php
@@ -33,6 +33,8 @@ trait ConnectionTrait
 
     private bool $hasBeenClosedWithAnOpenTransaction = false;
 
+    private bool $currentlyOpeningFirstLevelTransaction = false;
+
     private ?\ReflectionProperty $selfReflectionNestingLevelProperty = null;
 
     public function __construct(
@@ -174,14 +176,20 @@ trait ConnectionTrait
 
     public function beginTransaction(): void
     {
+        if ($this->getTransactionNestingLevel() === 0) {
+            $this->currentlyOpeningFirstLevelTransaction = true;
+        }
+
         $this->doWithRetry(function (): void {
             parent::beginTransaction();
         });
+
+        $this->currentlyOpeningFirstLevelTransaction = false;
     }
 
     public function canTryAgain(\Throwable $throwable, string $sql = null): bool
     {
-        if ($this->hasBeenClosedWithAnOpenTransaction) {
+        if ($this->hasBeenClosedWithAnOpenTransaction && ! $this->currentlyOpeningFirstLevelTransaction) {
             return false;
         }
 

--- a/tests/Functional/ConnectionTraitTest.php
+++ b/tests/Functional/ConnectionTraitTest.php
@@ -215,7 +215,7 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
         $this->forceDisconnect($connection);
 
         if ($driver instanceof PDODriver) {
-            $this->expectException(Driver\PDO\Exception::class);
+            $this->expectException(\Throwable::class);
             $this->expectExceptionMessage('MySQL server has gone away');
         }
 

--- a/tests/Functional/ConnectionTraitTest.php
+++ b/tests/Functional/ConnectionTraitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Facile\DoctrineMySQLComeBack\Tests\Functional;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\PDO\MySQL\Driver as PDODriver;
 use Doctrine\DBAL\Exception;
@@ -214,12 +215,17 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
 
-        if ($driver instanceof PDODriver) {
-            $this->expectException(\Throwable::class);
-            $this->expectExceptionMessage('MySQL server has gone away');
+        try {
+            $connection->beginTransaction();
+        } catch (\Throwable $e) {
+            $this->assertStringContainsString('MySQL server has gone away', $e->getMessage());
+
+            return;
         }
 
-        $connection->beginTransaction();
+        if ($driver instanceof PDODriver) {
+            $this->fail();
+        }
     }
 
     /**
@@ -235,7 +241,7 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
 
         $connection->beginTransaction();
 
-        if ($driver instanceof PDODriver) {
+        if ($this->isDbalBehaviorUniform() || $driver instanceof PDODriver) {
             $this->assertConnectionCount(2, $connection);
         } else {
             $this->assertConnectionCount(1, $connection);
@@ -292,5 +298,15 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
 
         $this->expectException(ConnectionLost::class);
         $statement->executeQuery();
+    }
+
+    /**
+     * @see https://github.com/doctrine/dbal/pull/6812
+     * DBAL behavior on connection issues changed in 4.2.3, introducing this new method.
+     * Before, drivers would behave differently; now, all drivers close the connection explicitly before throwing.
+     */
+    private function isDbalBehaviorUniform(): bool
+    {
+        return method_exists(Connection::class, 'handleDriverException');
     }
 }


### PR DESCRIPTION
It seems that recently DBAL introduced some changes that broke our tests: https://github.com/facile-it/doctrine-mysql-come-back/actions/runs/13756440622/job/38464559403

This means that the driver behavior has changed, and is now more uniform; I could consider this a breaking change, but I'm not sure yet, I have to dig deeper...

Ping @greg0ire, can you point me to the possible recent change? This package has weekly CI runs and broke 3 days ago, so this must be VERY recent...