### PR TITLE
fixes #107, updating possible gone away exceptions

### DIFF
--- a/src/Detector/MySQLGoneAwayDetector.php
+++ b/src/Detector/MySQLGoneAwayDetector.php
@@ -9,12 +9,14 @@ class MySQLGoneAwayDetector implements GoneAwayDetector
         'MySQL server has gone away',
         'Lost connection to MySQL server during query',
         'Error while sending QUERY packet',
+        'The client was disconnected by the server because of inactivity',
     ];
 
     /** @var string[] */
     protected array $goneAwayInUpdateExceptions = [
         'MySQL server has gone away',
         'Error while sending QUERY packet',
+        'The client was disconnected by the server because of inactivity',
     ];
 
     public function isGoneAwayException(\Throwable $exception, ?string $sql = null): bool


### PR DESCRIPTION
php8.4 returns a different error code for wait timeouts for mysql servers running 8.0.24 and above, see https://www.php.net/manual/de/migration84.incompatible.php under MySQLnd