### PR TITLE
[2.x] Test with session timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 * ...
 
-## [2.1.0] - TBA
+## [2.1.0] - 2025-09-02
 * Bump minimum PHP version to 8.1
+* Intercept new timeout message in MySQL 8.0.24+ under PHP 8.4+ (thanks @ackermannd)
 
 ## [2.0.2] - 2025-04-22
 * Resolve PHP 8.4 deprecation (fix 2.0.1 tag)

--- a/src/Detector/MySQLGoneAwayDetector.php
+++ b/src/Detector/MySQLGoneAwayDetector.php
@@ -9,12 +9,14 @@ class MySQLGoneAwayDetector implements GoneAwayDetector
         'MySQL server has gone away',
         'Lost connection to MySQL server during query',
         'Error while sending QUERY packet',
+        'The client was disconnected by the server because of inactivity',
     ];
 
     /** @var string[] */
     protected array $goneAwayInUpdateExceptions = [
         'MySQL server has gone away',
         'Error while sending QUERY packet',
+        'The client was disconnected by the server because of inactivity',
     ];
 
     public function isGoneAwayException(\Throwable $exception, ?string $sql = null): bool

--- a/tests/Functional/AbstractFunctionalTestCase.php
+++ b/tests/Functional/AbstractFunctionalTestCase.php
@@ -52,6 +52,7 @@ abstract class AbstractFunctionalTestCase extends TestCase
     protected function getConnectedConnection(string $driver, int $attempts, bool $enableSavepoints): DBALConnection
     {
         $connection = $this->createConnection($driver, $attempts, $enableSavepoints);
+        $connection->executeQuery('SET SESSION WAIT_TIMEOUT=1');
         $connection->executeQuery('SELECT 1');
 
         return $connection;
@@ -133,6 +134,12 @@ abstract class AbstractFunctionalTestCase extends TestCase
             $connection2->executeStatement(sprintf('KILL %d', $id));
         }
         $connection2->close();
+    }
+
+    protected function forceDisconnectionByTimeout(DBALConnection $connection): void
+    {
+        $connection->executeQuery('SELECT 1');
+        sleep(2);
     }
 
     /**

--- a/tests/Functional/ConnectionTraitTest.php
+++ b/tests/Functional/ConnectionTraitTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\PDO\MySQL\Driver as PDODriver;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 class ConnectionTraitTest extends AbstractFunctionalTestCase
 {
@@ -37,6 +38,22 @@ class ConnectionTraitTest extends AbstractFunctionalTestCase
         $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
         $this->assertConnectionCount(1, $connection);
         $this->forceDisconnect($connection);
+
+        $connection->executeQuery('SELECT 1')->fetchAllNumeric();
+
+        $this->assertConnectionCount(2, $connection);
+    }
+
+    /**
+     * @param class-string<Driver> $driver
+     */
+    #[DataProvider('driverDataProvider')]
+    #[RequiresPhp('>=8.4.0')]
+    public function testExecuteQueryShouldReconnectAfterSessionTimeout(string $driver, bool $enableSavepoints): void
+    {
+        $connection = $this->getConnectedConnection($driver, 1, $enableSavepoints);
+        $this->assertConnectionCount(1, $connection);
+        $this->forceDisconnectionByTimeout($connection);
 
         $connection->executeQuery('SELECT 1')->fetchAllNumeric();
 

--- a/tests/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Functional/PrimaryReadReplicaConnectionTest.php
@@ -37,6 +37,7 @@ class PrimaryReadReplicaConnectionTest extends ConnectionTraitTest
         $connection = parent::getConnectedConnection($driver, $attempts, $enableSavepoints);
         $this->assertInstanceOf(PrimaryReadReplicaConnection::class, $connection);
         $connection->ensureConnectedToPrimary();
+        $connection->executeQuery('SET SESSION WAIT_TIMEOUT=1');
 
         return $connection;
     }


### PR DESCRIPTION
This should fix #107 in the 2.x branch; this is a port of #111, which is the same fix for the 3.x branch.