### PR TITLE
Add zizmor security analysis and harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -115,9 +115,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Rector + Code style
-            commandName: Run Rector + code style check
-            command: 'vendor/bin/rector --ansi --dry-run && vendor/bin/php-cs-fixer fix --dry-run --ansi --diff'
+          - name: Rector
+            commandName: Run Rector
+            command: 'vendor/bin/rector --ansi --dry-run'
+          - name: Code style
+            commandName: Run code style check
+            command: 'vendor/bin/php-cs-fixer fix --dry-run --ansi --diff'
           - name: Psalm
             commandName: Run Psalm analysis
             command: vendor/bin/psalm --show-info=true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,13 @@ on:
   schedule:
     - cron: "42 3 * * 1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   phpunit-mysql:
     name: ${{ matrix.job }}${{ matrix.name }} (PHP ${{ matrix.php-version }} / MySQL ${{ matrix.mysql-version }})
@@ -41,9 +48,10 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: 'Use CI Docker Compose override configuration'
         run: 'cp docker-compose.ci.override.yml docker-compose.override.yml'
@@ -54,7 +62,7 @@ jobs:
           MYSQL_VERSION: "${{ matrix.mysql-version }}"
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
@@ -76,7 +84,7 @@ jobs:
             vimeo/psalm
 
       - name: Install dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: ${{ matrix.composer-options }}
@@ -95,7 +103,7 @@ jobs:
         if: matrix.job == 'infection'
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -116,20 +124,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Install PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.5
 
       - name: Install dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           dependency-versions: highest
           composer-options: --prefer-dist
 
       - name: ${{ matrix.commandName }}
-        run: ${{ matrix.command }}
+        env:
+          COMMAND: ${{ matrix.command }}
+        run: $COMMAND

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -117,7 +117,7 @@ jobs:
         include:
           - name: Rector + Code style
             commandName: Run Rector + code style check
-            command: vendor/bin/rector --ansi --dry-run && vendor/bin/php-cs-fixer fix --dry-run --ansi --verbose
+            command: 'vendor/bin/rector --ansi --dry-run && vendor/bin/php-cs-fixer fix --dry-run --ansi --diff'
           - name: Psalm
             commandName: Run Psalm analysis
             command: vendor/bin/psalm --show-info=true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches:
+      - "3.x"
+    paths:
+      - '.github/**.yml'
+      - '.github/**.yaml'
+  pull_request:
+    paths:
+      - '.github/**.yml'
+      - '.github/**.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false
+          annotations: true
+          persona: 'pedantic'


### PR DESCRIPTION
## Summary

- Add a `zizmor.yml` workflow (pedantic persona) that runs on changes under `.github/`.
- Add a 7-day Dependabot cooldown for both `github-actions` and `composer` ecosystems.
- Harden `continuous-integration.yml` to pass zizmor pedantic checks:
  - Pin all third-party actions to latest release SHAs
  - Set explicit `permissions: contents: read` and workflow-level concurrency
  - Disable credential persistence on read-only checkouts
  - Move matrix command into step `env` to avoid template injection

## Test plan

- [x] Local zizmor run reports "No findings to report"
- [x] CI zizmor check passes on this PR
- [ ] Existing CI jobs (PHPUnit, quality checks) still pass


Made with [Cursor](https://cursor.com)